### PR TITLE
~/.local/bin/scm: add #! line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ eclipse:
 	mvn eclipse:eclipse
 
 $(HOME)/.local/bin/scm:
-	echo "java -jar $(HOME)/.local/share/scm/scm.jar" > $@
+	(echo "#!/bin/sh"; echo "java -jar $(HOME)/.local/share/scm/scm.jar") > $@
 	chmod u+x $@
 
 install: target/scm-1.0-SNAPSHOT-jar-with-dependencies.jar  $(HOME)/.local/bin/scm


### PR DESCRIPTION
Hi, found this from https://github.com/jonas/tig/issues/775 :wave:

I think Bourne shell (and bash) has a hack to interpret scripts even without `#!` (https://stackoverflow.com/a/12296783/239657), in other shells this may not work...  In fish it didn't.
Having `#!` line allows any process to exec it.